### PR TITLE
Making labels optionals

### DIFF
--- a/src/Model/AbstractObject.php
+++ b/src/Model/AbstractObject.php
@@ -2,6 +2,7 @@
 namespace TheCodingMachine\GitlabHook\Model;
 
 use TheCodingMachine\GitlabHook\GitlabHookException;
+use function array_key_exists;
 
 abstract class AbstractObject
 {
@@ -78,6 +79,16 @@ abstract class AbstractObject
         return $array;
     }
 
+    protected function hasAttribute(string $key, string $subArray = null): bool
+    {
+        if (null !== $subArray) {
+            $array = $this->getKey($subArray, $this->payload);
+        } else {
+            $array = $this->payload;
+        }
+        return array_key_exists($key, $array);
+    }
+
     /**
      * @param string $key
      * @param string|null $subArray
@@ -104,7 +115,7 @@ abstract class AbstractObject
     private function getKey(string $key, array $array)
     {
         if (!array_key_exists($key, $array)) {
-            throw new GitlabHookException("Variable ".$key." doesn't exist in ".get_class($this)." model");
+            throw new GitlabHookException("Variable '".$key."' doesn't exist in ".get_class($this)." model");
         }
         return $array[$key];
     }

--- a/src/Model/Base/Change.php
+++ b/src/Model/Base/Change.php
@@ -24,12 +24,14 @@ class Change extends AbstractObject
     public function __construct(array $payload)
     {
         parent::__construct($payload);
-        $labels = $this->getAttribute('labels');
-        foreach ($labels['previous'] as $label) {
-            $this->labelsPrevious[] = new Label($label);
-        }
-        foreach ($labels['current'] as $label) {
-            $this->labelsCurrent[] = new Label($label);
+        if ($this->hasAttribute('labels')) {
+            $labels = $this->getAttribute('labels');
+            foreach ($labels['previous'] as $label) {
+                $this->labelsPrevious[] = new Label($label);
+            }
+            foreach ($labels['current'] as $label) {
+                $this->labelsCurrent[] = new Label($label);
+            }
         }
     }
 


### PR DESCRIPTION
In new versions of Gitlab (12.x), it seems that labels can be absent of "Change" hooks.
This PR makes Gitlab-hook-middleware not crash on such cases.